### PR TITLE
fix: the environment variable LOCAL_SIZE has been renamed in LOCAL_WORLD_SIZE

### DIFF
--- a/bagua/distributed/launch.py
+++ b/bagua/distributed/launch.py
@@ -200,7 +200,7 @@ def main():
         dist_rank = args.nproc_per_node * args.node_rank + local_rank
         current_env["RANK"] = str(dist_rank)
         current_env["LOCAL_RANK"] = str(local_rank)
-        current_env["LOCAL_SIZE"] = str(args.nproc_per_node)
+        current_env["LOCAL_WORLD_SIZE"] = str(args.nproc_per_node)
 
         # spawn the processes
         with_python = not args.no_python

--- a/bagua/torch_api/env.py
+++ b/bagua/torch_api/env.py
@@ -45,7 +45,7 @@ def get_local_size():
     Returns:
         The local size of the node.
     """
-    return int(os.environ.get("LOCAL_SIZE", 1))
+    return int(os.environ.get("LOCAL_WORLD_SIZE", 1))
 
 
 def get_default_bucket_size() -> int:


### PR DESCRIPTION
 The environment variable LOCAL_SIZE has been renamed in `distributed.run`, fix it.