### PR TITLE
chore(python): support for elastic_bagua

### DIFF
--- a/bagua/torch_api/distributed.py
+++ b/bagua/torch_api/distributed.py
@@ -113,6 +113,7 @@ class BaguaModule:
 
         return self
 
+    @torch.jit.unused
     @property
     def bagua_module_name(self):
         """
@@ -124,14 +125,17 @@ class BaguaModule:
     def bagua_module_name(self, name: str):
         self._bagua_module_name = name
 
+    @torch.jit.unused
     @property
     def bagua_algorithm(self):
         return self.bagua_ddp.bagua_algorithm
 
+    @torch.jit.unused
     @property
     def bagua_optimizers(self):
         return self.bagua_ddp.bagua_optimizers
 
+    @torch.jit.unused
     @property
     def bagua_buckets(self):
         return self.bagua_ddp.bagua_buckets


### PR DESCRIPTION
To implement automatic elastic training which executes from distributed training to single-machine single-card training, we introduce `elastic_bagua` containing `elastic_bagua.save()/load()` based on [torch.save()/load()](https://github.com/pytorch/pytorch/blob/v1.10.0/torch/serialization.py) inside company. This pr aims to fix some bugs in `elastic_bagua.save()/load()` CI test which based on [torch.save()/load() CI test](https://github.com/pytorch/pytorch/blob/v1.10.0/test/test_serialization.py). 

Bug is shown below:
```
self = <test_serialization.TestSerialization testMethod=test_serialization_zipfile_actually_jit>

    def test_serialization_zipfile_actually_jit(self):
        with tempfile.NamedTemporaryFile() as f:
>           torch.jit.save(torch.jit.script(torch.nn.Linear(3, 4)), f)

test_serialization.py:777: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/conda/lib/python3.7/site-packages/torch/jit/_script.py:1258: in script
    obj, torch.jit._recursive.infer_methods_to_compile
/opt/conda/lib/python3.7/site-packages/torch/jit/_recursive.py:451: in create_script_module
    return create_script_module_impl(nn_module, concrete_type, stubs_fn)
/opt/conda/lib/python3.7/site-packages/torch/jit/_recursive.py:517: in create_script_module_impl
    create_methods_and_properties_from_stubs(concrete_type, method_stubs, property_stubs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

concrete_type = <torch._C.ConcreteModuleType object at 0x7fdf0c1293b0>
method_stubs = [ScriptMethodStub(resolution_callback=<function createResolutionCallbackFromEnv.<locals>.<lambda> at 0x7fdf0c12b680>, ...at 0x7fdf0c0ad0b0>, original_method=<bound method Linear.forward of Linear(in_features=3, out_features=4, bias=True)>)]
property_stubs = [PropertyStub(resolution_callback=<function createResolutionCallbackFromEnv.<locals>.<lambda> at 0x7fdf0c0b6320>, def_=<torch._C._jit_tree_views.Property object at 0x7fdf0c0adeb0>)]

    def create_methods_and_properties_from_stubs(concrete_type, method_stubs, property_stubs):
        method_defs = [m.def_ for m in method_stubs]
        method_rcbs = [m.resolution_callback for m in method_stubs]
        method_defaults = [get_default_args(m.original_method) for m in method_stubs]
    
        property_defs = [p.def_ for p in property_stubs]
        property_rcbs = [p.resolution_callback for p in property_stubs]
    
>       concrete_type._create_methods_and_properties(property_defs, property_rcbs, method_defs, method_rcbs, method_defaults)
E       RuntimeError: 
E       Module 'Linear' has no attribute '_bagua_module_name' :
E         File "/home/suntengxu/bagua-master/bagua/torch_api/distributed.py", line 122
E               The module's name. Bagua uses the module name to distinguish different modules.
E               """
E               return self._bagua_module_name
E                      ~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE

/opt/conda/lib/python3.7/site-packages/torch/jit/_recursive.py:368: RuntimeError
```