### PR TITLE
[ci] precompiled bagua-cuda116

### DIFF
--- a/.github/workflows/bagua-pypi-publish.yml
+++ b/.github/workflows/bagua-pypi-publish.yml
@@ -53,6 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda-version:
+          - "116"
           - "115"
           - "113"
           - "111"
@@ -87,6 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda-version:
+          - "116"
           - "115"
           - "113"
           - "111"

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -48,6 +48,7 @@ jobs:
           - "111"
           - "113"
           - "115"
+          - "116"
     name: 'Build'
     runs-on: ubuntu-latest
     steps:

--- a/bagua_core/bagua_install_deps.py
+++ b/bagua_core/bagua_install_deps.py
@@ -47,6 +47,9 @@ def _make_nccl_record(cuda_version, full_version, public_version, filename_linux
 
 
 _nccl_records.append(
+    _make_nccl_record("11.6", "2.11.4", "2.11", "nccl_2.11.4-1+cuda11.4_x86_64.txz")
+)
+_nccl_records.append(
     _make_nccl_record("11.5", "2.11.4", "2.11", "nccl_2.11.4-1+cuda11.4_x86_64.txz")
 )
 _nccl_records.append(

--- a/docker/Dockerfile.manylinux-cuda116
+++ b/docker/Dockerfile.manylinux-cuda116
@@ -1,0 +1,22 @@
+FROM pytorch/manylinux-cuda116
+
+RUN yum install centos-release-scl-rh -y && yum install devtoolset-8-toolchain -y
+RUN yum remove okay-release -y && yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
+RUN yum remove cmake3 -y && yum install cmake3 -y
+RUN yum install -y openmpi3-devel openmpi3 hwloc-devel perl-IPC-Cmd
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
+
+RUN yum install -y python3-devel zlib-devel openssl-devel
+RUN python3 -m pip install setuptools-rust colorama tqdm wheel -i https://pypi.org/simple
+
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+
+RUN echo "source /root/.cargo/env && source /opt/rh/devtoolset-8/enable && source /etc/profile.d/modules.sh && module load mpi || exit 1" >> /etc/profile
+
+ENTRYPOINT ["sh", "-l", "-c", "\"$@\"", "-s"]
+
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs/:/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="/usr/local/cuda/lib64/stubs/:/usr/local/lib64:/usr/local/lib:${LIBRARY_PATH}"
+ENV PKG_CONFIG_PATH="/usr/local/cuda/pkgconfig/:${PKG_CONFIG_PATH}"
+ENV CUDA_LIBRARY_PATH="/usr/local/cuda/lib64/"


### PR DESCRIPTION
Related PR: [[CI] Bump CUDA in Docker images to 11.6.1](https://github.com/Lightning-AI/lightning/pull/14348#pullrequestreview-1080799556).