### PR TITLE
fix: fail to compile Aluminum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,17 +60,19 @@ if __name__ == "__main__":
         return False
 
     if (
-        int(os.getenv("BAGUA_NO_INSTALL_DEPS", 0)) == 0
-        and len(sys.argv) > 1
+        len(sys.argv) > 1
         and check_args(sys.argv)  # noqa: W503
     ):
-        print(
-            colorama.Fore.BLACK
-            + colorama.Back.CYAN
-            + "Bagua is automatically installing some system dependencies like bagua-net, to disable set env variable BAGUA_NO_INSTALL_DEPS=1",
-        )
-        os.system("python3 bagua_core/bagua_install_deps.py")
-        install_dependency_library()
+        if int(os.getenv("BAGUA_NO_INSTALL_DEPS", 0)) == 0:
+            print(
+                colorama.Fore.BLACK
+                + colorama.Back.CYAN
+                + "Bagua is automatically installing some system dependencies like bagua-net, to disable set env variable BAGUA_NO_INSTALL_DEPS=1",
+            )
+            os.system("python3 bagua_core/bagua_install_deps.py")
+            install_dependency_library()
+        else:
+            os.makedirs(os.path.join(cwd, "bagua_core", ".data"), exist_ok=True)
 
     name_suffix = os.getenv("BAGUA_CUDA_VERSION", "")
     if name_suffix != "":


### PR DESCRIPTION
fix: <https://github.com/BaguaSys/bagua/issues/561>

Fail to compile bagua using this command `python3 setup.py install`.

Error info:
```
   Compiling bagua-core-internal v0.1.2 (bagua/rust/bagua-core/bagua-core-intern
       Fresh reqwest v0.11.10
       Fresh bagua-opentelemetry v0.1.0 (bagua/rust/bagua-core/bagua-opentelemet
     Running `bagua/rust/bagua-core/target/release/build/bagua-core-internal-4c1
The following warnings were emitted during compilation:

warning: nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprece release (Use -Wno-deprecated-gpu-targets to suppress warning).
warning: nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprece release (Use -Wno-deprecated-gpu-targets to suppress warning).

error: failed to run custom build command for `bagua-core-internal v0.1.2`
...

  running: "cmake" "/home/xxx/bagua/rust/bagua-core/bagua-core-internal/third_party/AluminUMINUM_ENABLE_NCCL=YES" "-DCUB_INCLUDE_PATH=/home/xxx/bagua/rust/bagua-core/bagua-core-intL_LIBRARY=/home/xxx/.local/share/bagua/nccl/lib/libnccl.so" "-DNCCL_INCLUDE_PATH=/home/xxx/.local/share/bagua/nccl/"-DCMAKE_INSTALL_PREFIX=/home/xxx/bagua/rust/bagua-core/bagua-core-internal/../../../baguanction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -std=c++17 -ffunction-sectDCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILERelease"

  --- stderr
  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?

  build script failed, must exit now', /home/xxx/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.48/src/lib.r
  stack backtrace:
     0:     0x561b46b89b1c - std::backtrace_rs::backtrace::libunwind::trace::hd3a6cb8e32f9fc43
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/../../backtrace/src/bac
     1:     0x561b46b89b1c - std::backtrace_rs::backtrace::trace_unsynchronized::h6dcceebcd6a9f2ab
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/../../backtrace/src/bac
     2:     0x561b46b89b1c - std::sys_common::backtrace::_print_fmt::h4eacf4e9ad977499
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/sys_common/backtrace.rs
     3:     0x561b46b89b1c - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h1e42c22572
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/sys_common/backtrace.rs
     4:     0x561b46babdac - core::fmt::write::h072b578a8e90aa54
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/fmt/mod.rs:1150:17
     5:     0x561b46b85c15 - std::io::Write::write_fmt::hc32d3cabefff1d24
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/io/mod.rs:1667:15
     6:     0x561b46b8be40 - std::sys_common::backtrace::_print::h058b85b6efc15780
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/sys_common/backtrace.rs
     7:     0x561b46b8be40 - std::sys_common::backtrace::print::hdb7de10b704104b4
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/sys_common/backtrace.rs
     8:     0x561b46b8be40 - std::panicking::default_hook::{{closure}}::h5451997d203bda2f
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:210:50
     9:     0x561b46b8b9f7 - std::panicking::default_hook::h419b121e68f746a2
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:227:9
    10:     0x561b46b8c4f4 - std::panicking::rust_panic_with_hook::h32c44b1364c1c247
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:624:17
    11:     0x561b46b8bfd0 - std::panicking::begin_panic_handler::{{closure}}::he2e5f48fb16982d1
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:521:13
    12:     0x561b46b89fc4 - std::sys_common::backtrace::__rust_end_short_backtrace::haea54a33f9e18aba
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/sys_common/backtrace.rs
    13:     0x561b46b8bf39 - rust_begin_unwind
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:517:5
    14:     0x561b4669b14b - std::panicking::begin_panic_fmt::hfe65ef178b63b848
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:460:5
    15:     0x561b46ab7bfc - cmake::fail::h91662c8101c7c0e0
    16:     0x561b46ab7413 - cmake::run::h8578cd28992ef855
    17:     0x561b46ab404d - cmake::Config::build::h5b4e706a8dea8076
    18:     0x561b4669e662 - build_script_build::main::hb005a97ebd38aaee
    19:     0x561b466a4673 - core::ops::function::FnOnce::call_once::hc15f66ac8af0c4b6
    20:     0x561b466a3f19 - std::sys_common::backtrace::__rust_begin_short_backtrace::hd0073108c8acc9f7
    21:     0x561b466a2959 - std::rt::lang_start::{{closure}}::hc336f5d477f8f246
    22:     0x561b46b8cafa - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h97e9d5f2
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/ops/function.rs:259:13
    23:     0x561b46b8cafa - std::panicking::try::do_call::hdfecd950eba8f698
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:403:40
    24:     0x561b46b8cafa - std::panicking::try::h3c77c8ba3eb0735c
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:367:19
    25:     0x561b46b8cafa - std::panic::catch_unwind::h8e0d62076d8d837e
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panic.rs:129:14
    26:     0x561b46b8cafa - std::rt::lang_start_internal::{{closure}}::h647045b4c6a22e67
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/rt.rs:45:48
    27:     0x561b46b8cafa - std::panicking::try::do_call::h905d96e4a757647e
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:403:40
    28:     0x561b46b8cafa - std::panicking::try::hc113426beb3c908b
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:367:19
    29:     0x561b46b8cafa - std::panic::catch_unwind::h74f684ea7038ea12
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panic.rs:129:14
    30:     0x561b46b8cafa - std::rt::lang_start_internal::h5ba185919d396c97
                                 at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/rt.rs:45:20
    31:     0x561b466a2931 - std::rt::lang_start::h919734b2799d4ded
    32:     0x561b4669fe73 - main
    33:     0x7f36695880b3 - __libc_start_main
    34:     0x561b4669d0ae - _start
    35:                0x0 - <unknown>
error: cargo failed with code: 101
```