### PR TITLE
ci: update default CUDA version in baguasys/manylinux-cuda:XXX

### DIFF
--- a/docker/Dockerfile.manylinux-cuda111
+++ b/docker/Dockerfile.manylinux-cuda111
@@ -1,5 +1,8 @@
 FROM pytorch/manylinux-cuda111
 
+RUN rm -rf /usr/local/cuda
+RUN ln -s /usr/local/cuda-11.1 /usr/local/cuda
+
 RUN yum install centos-release-scl-rh -y && yum install devtoolset-8-toolchain -y
 RUN yum remove okay-release -y && yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
 RUN yum remove cmake3 -y && yum install cmake3 -y

--- a/docker/Dockerfile.manylinux-cuda113
+++ b/docker/Dockerfile.manylinux-cuda113
@@ -1,5 +1,8 @@
 FROM pytorch/manylinux-cuda113
 
+RUN rm -rf /usr/local/cuda
+RUN ln -s /usr/local/cuda-11.3 /usr/local/cuda
+
 RUN yum install centos-release-scl-rh -y && yum install devtoolset-8-toolchain -y
 RUN yum remove okay-release -y && yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
 RUN yum remove cmake3 -y && yum install cmake3 -y

--- a/docker/Dockerfile.manylinux-cuda115
+++ b/docker/Dockerfile.manylinux-cuda115
@@ -1,5 +1,9 @@
 FROM pytorch/manylinux-cuda115
 
+
+RUN rm -rf /usr/local/cuda
+RUN ln -s /usr/local/cuda-11.5 /usr/local/cuda
+
 RUN yum install centos-release-scl-rh -y && yum install devtoolset-8-toolchain -y
 RUN yum remove okay-release -y && yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
 RUN yum remove cmake3 -y && yum install cmake3 -y

--- a/docker/Dockerfile.manylinux-cuda116
+++ b/docker/Dockerfile.manylinux-cuda116
@@ -1,5 +1,8 @@
 FROM pytorch/manylinux-cuda116
 
+RUN rm -rf /usr/local/cuda
+RUN ln -s /usr/local/cuda-11.6 /usr/local/cuda
+
 RUN yum install centos-release-scl-rh -y && yum install devtoolset-8-toolchain -y
 RUN yum remove okay-release -y && yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm -y
 RUN yum remove cmake3 -y && yum install cmake3 -y


### PR DESCRIPTION
The default CUDA version is 10.2 in all docker images `baguasys/manylinux-cuda:XXX` which will be used to build python wheel in `.github/workflows/bagua-pypi-publish.yml`.

[Build info](https://github.com/BaguaSys/bagua/actions/runs/4091401814/jobs/7311956603):

```
2023-02-18T19:42:07.4286942Z ##[group]Starting Docker image baguasys/manylinux-cuda:116...
2023-02-18T19:42:07.4287425Z 
2023-02-18T19:42:07.4513482Z Unable to find image 'baguasys/manylinux-cuda:116' locally
2023-02-18T19:42:07.8043977Z 116: Pulling from baguasys/manylinux-cuda
2023-02-18T19:42:07.8044359Z 2d473b07cdd5: Pulling fs layer
...
2023-02-18T19:45:45.4443608Z Digest: sha256:dc3876aa1f385835798b464c7079aa9f03f86e792194e18be5f9e8a38b52f6a9
2023-02-18T19:45:45.4462770Z Status: Downloaded newer image for baguasys/manylinux-cuda:116
2023-02-18T19:45:45.4766274Z 093392cae69c7fb4f8e1974d57210738c77623fa5abc94955196670841395de5
2023-02-18T19:45:45.4788185Z     + /bin/true
2023-02-18T19:45:45.8782839Z ##[endgroup]
2023-02-18T19:45:45.8785948Z                                                             [32m✓ [0m218.45s
2023-02-18T19:45:45.8786880Z ##[group]Copying project into Docker...
2023-02-18T19:45:45.8787134Z 
2023-02-18T19:45:45.8787819Z     + mkdir -p /project
2023-02-18T19:45:46.1566424Z ##[endgroup]
2023-02-18T19:45:46.1567238Z                                                               [32m✓ [0m0.28s
2023-02-18T19:45:46.1567487Z 
2023-02-18T19:45:46.1567790Z [1m[34mBuilding cp37-manylinux_x86_64 wheel[0m
2023-02-18T19:45:46.1568128Z CPython 3.7 manylinux x86_64
2023-02-18T19:45:46.1568346Z 
2023-02-18T19:45:46.2374373Z ##[group]Setting up build environment...
2023-02-18T19:45:46.2374813Z 
2023-02-18T19:45:46.2377608Z     + /opt/python/cp38-cp38/bin/python -c 'import sys, json, os; json.dump(os.environ.copy(), sys.stdout)'
2023-02-18T19:45:46.2961727Z     + which python
2023-02-18T19:45:46.3028167Z     + which pip
2023-02-18T19:45:46.3083808Z ##[endgroup]
2023-02-18T19:45:46.3084562Z                                                               [32m✓ [0m0.07s
2023-02-18T19:45:46.3085088Z ##[group]Running before_build...
2023-02-18T19:45:46.3085323Z 
2023-02-18T19:45:46.3086148Z     + sh -c 'pip install git+https://github.com/rossant/auditwheel.git@include-exclude'
2023-02-18T19:45:47.8478879Z   Running command git clone --filter=blob:none --quiet https://github.com/rossant/auditwheel.git /tmp/pip-req-build-j76_p8z4
2023-02-18T19:45:48.7088626Z   Running command git checkout -b include-exclude --track origin/include-exclude
2023-02-18T19:45:49.0071713Z   Switched to a new branch 'include-exclude'
2023-02-18T19:45:49.0075370Z   branch 'include-exclude' set up to track 'origin/include-exclude'.
2023-02-18T19:45:52.1452997Z WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
2023-02-18T19:45:52.2105004Z 
2023-02-18T19:45:52.2105623Z [notice] A new release of pip is available: 23.0 -> 23.0.1
2023-02-18T19:45:52.2106101Z [notice] To update, run: python -m pip install --upgrade pip
2023-02-18T19:45:52.2898455Z Collecting git+https://github.com/rossant/auditwheel.git@include-exclude
2023-02-18T19:45:52.2900591Z   Cloning https://github.com/rossant/auditwheel.git (to revision include-exclude) to /tmp/pip-req-build-j76_p8z4
2023-02-18T19:45:52.2939590Z   Resolved https://github.com/rossant/auditwheel.git to commit 607b8f7e978beaff12de9810a772fe0d64136bc2
2023-02-18T19:45:52.2939987Z   Installing build dependencies: started
2023-02-18T19:45:52.2941742Z   Installing build dependencies: finished with status 'done'
2023-02-18T19:45:52.2942074Z   Getting requirements to build wheel: started
2023-02-18T19:45:52.2942468Z   Getting requirements to build wheel: finished with status 'done'
2023-02-18T19:45:52.2942795Z   Preparing metadata (pyproject.toml): started
2023-02-18T19:45:52.2943183Z   Preparing metadata (pyproject.toml): finished with status 'done'
2023-02-18T19:45:52.2943965Z Requirement already satisfied: importlib-metadata in /opt/_internal/cpython-3.7.5/lib/python3.7/site-packages (from auditwheel==4.0.1.dev6) (6.0.0)
2023-02-18T19:45:52.2944637Z Requirement already satisfied: pyelftools>=0.24 in /opt/_internal/cpython-3.7.5/lib/python3.7/site-packages (from auditwheel==4.0.1.dev6) (0.29)
2023-02-18T19:45:52.2945310Z Requirement already satisfied: zipp>=0.5 in /opt/_internal/cpython-3.7.5/lib/python3.7/site-packages (from importlib-metadata->auditwheel==4.0.1.dev6) (3.12.0)
2023-02-18T19:45:52.2946053Z Requirement already satisfied: typing-extensions>=3.6.4 in /opt/_internal/cpython-3.7.5/lib/python3.7/site-packages (from importlib-metadata->auditwheel==4.0.1.dev6) (4.4.0)
2023-02-18T19:45:52.2946500Z Building wheels for collected packages: auditwheel
2023-02-18T19:45:52.2946803Z   Building wheel for auditwheel (pyproject.toml): started
2023-02-18T19:45:52.2947225Z   Building wheel for auditwheel (pyproject.toml): finished with status 'done'
2023-02-18T19:45:52.2947877Z   Created wheel for auditwheel: filename=auditwheel-4.0.1.dev6-py3-none-any.whl size=49493 sha256=84134e91121625a7c276d5e5187713ffde218dd5b59a9cdbbd58cbe99f3522bd
2023-02-18T19:45:52.2948560Z   Stored in directory: /tmp/pip-ephem-wheel-cache-55crlcw1/wheels/6f/1f/0b/b88ab34b31f4cb52b822d0e07bf3897e73c8703089010a64aa
2023-02-18T19:45:52.2948929Z Successfully built auditwheel
2023-02-18T19:45:52.2949176Z Installing collected packages: auditwheel
2023-02-18T19:45:52.2949438Z   Attempting uninstall: auditwheel
2023-02-18T19:45:52.2949709Z     Found existing installation: auditwheel 5.3.0
2023-02-18T19:45:52.2950035Z     Uninstalling auditwheel-5.3.0:
2023-02-18T19:45:52.2950365Z       Successfully uninstalled auditwheel-5.3.0
2023-02-18T19:45:52.2950715Z Successfully installed auditwheel-4.0.1.dev6
2023-02-18T19:45:52.2952832Z ##[endgroup]
2023-02-18T19:45:52.2953255Z                                                               [32m✓ [0m5.98s
2023-02-18T19:45:52.2953681Z ##[group]Building wheel...
2023-02-18T19:45:52.2953828Z 
2023-02-18T19:45:52.2954003Z     + rm -rf /tmp/cibuildwheel/built_wheel
2023-02-18T19:45:52.2954341Z     + mkdir -p /tmp/cibuildwheel/built_wheel
2023-02-18T19:45:52.2978417Z     + python -m pip wheel /project --wheel-dir=/tmp/cibuildwheel/built_wheel --no-deps
2023-02-18T19:57:41.9180548Z   error: subprocess-exited-with-error
2023-02-18T19:57:41.9181980Z   
2023-02-18T19:57:41.9183394Z   × Building wheel for bagua-cuda116 (pyproject.toml) did not run successfully.
2023-02-18T19:57:41.9183854Z   │ exit code: 1
2023-02-18T19:57:41.9184149Z   ╰─> [1416 lines of output]
2023-02-18T19:57:41.9184751Z       Bagua is automatically installing some system dependencies like bagua-net, to disable set env variable BAGUA_NO_INSTALL_DEPS=1
2023-02-18T19:57:41.9185120Z       nvcc_version:  10.2
2023-02-18T19:57:41.9185522Z       Installing nccl 2.11.4 for CUDA 10.2 to: /root/.local/share/bagua/nccl
2023-02-18T19:57:41.9186191Z       Downloading https://developer.download.nvidia.com/compute/redist/nccl/v2.11/nccl_2.11.4-1+cuda10.2_x86_64.txz...
2023-02-18T19:57:41.9186519Z       
2023-02-18T19:57:41.9186955Z       nccl_2.11.4-1+cuda10.2_x86_64.txz: 0.00B [00:00, ?B/s]
2023-02-18T19:57:41.9187370Z       nccl_2.11.4-1+cuda10.2_x86_64.txz:   9%|▉         | 9.85M/111M [00:00<00:01, 98.4MB/s]
2023-02-18T19:57:41.9187930Z       nccl_2.11.4-1+cuda10.2_x86_64.txz:  36%|███▌      | 40.2M/111M [00:00<00:00, 219MB/s]
2023-02-18T19:57:41.9188460Z       nccl_2.11.4-1+cuda10.2_x86_64.txz:  64%|██████▎   | 70.8M/111M [00:00<00:00, 259MB/s]
2023-02-18T19:57:41.9188889Z       nccl_2.11.4-1+cuda10.2_x86_64.txz:  85%|████████▌ | 94.8M/111M [00:00<00:00, 251MB/s]
2023-02-18T19:57:41.9189396Z       nccl_2.11.4-1+cuda10.2_x86_64.txz: 111MB [00:00, 245MB/s]
2023-02-18T19:57:41.9189629Z       Extracting...
2023-02-18T19:57:41.9189823Z       Installing...
2023-02-18T19:57:41.9190130Z       Cleaning up...
2023-02-18T19:57:41.9190322Z       Done!
2023-02-18T19:57:41.9190514Z       nvcc_version:  10.2
2023-02-18T19:57:41.9191021Z       cargo build --release && cp ../target/release/libbagua_net.a ./libbagua_net.a
2023-02-18T19:57:41.9191693Z           Updating crates.io index
2023-02-18T19:57:41.9191955Z        Downloading crates ...
2023-02-18T19:57:41.9192409Z         Downloaded aho-corasick v0.7.18
2023-02-18T19:57:41.9192684Z         Downloaded form_urlencoded v1.0.1
2023-02-18T19:57:41.9193141Z         Downloaded pin-utils v0.1.0
2023-02-18T19:57:41.9193457Z         Downloaded futures-task v0.3.21
2023-02-18T19:57:41.9193885Z         Downloaded futures-macro v0.3.21
2023-02-18T19:57:41.9194133Z         Downloaded rand v0.8.4
2023-02-18T19:57:41.9194361Z         Downloaded rand_chacha v0.3.1
2023-02-18T19:57:41.9194715Z         Downloaded nanorand v0.7.0
2023-02-18T19:57:41.9195014Z         Downloaded kv-log-macro v1.0.7
2023-02-18T19:57:41.9195368Z         Downloaded once_cell v1.8.0
```