### PR TITLE
fix: use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11

### DIFF
--- a/bagua/bagua_define.py
+++ b/bagua/bagua_define.py
@@ -2,7 +2,8 @@ import enum
 from typing import List
 import sys
 
-if sys.version_info >= (3, 9):
+# Use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.
+if sys.version_info >= (3, 11):
     from typing import TypedDict  # pytype: disable=not-supported-yet
 else:
     from typing_extensions import TypedDict  # pytype: disable=not-supported-yet


### PR DESCRIPTION
Fixes the error on Python 3.10.

```
Traceback (most recent call last):
  File "/home/wr/conda-workspace/bagua/examples/benchmark/synthetic_benchmark.py", line 14, in <module>
    import bagua.torch_api as bagua
  File "/home/wr/conda-workspace/bagua/bagua/torch_api/__init__.py", line 25, in <module>
    from .communication import (  # noqa: F401
  File "/home/wr/conda-workspace/bagua/bagua/torch_api/communication.py", line 7, in <module>
    from bagua.service import AutotuneService
  File "/home/wr/conda-workspace/bagua/bagua/service/__init__.py", line 1, in <module>
    from .autotune_service import AutotuneService, AutotuneClient  # noqa: F401
  File "/home/wr/conda-workspace/bagua/bagua/service/autotune_service.py", line 9, in <module>
    from .autotune_task_manager import AutotuneTaskManager
  File "/home/wr/conda-workspace/bagua/bagua/service/autotune_task_manager.py", line 14, in <module>
    from bagua.bagua_define import (
  File "/home/wr/conda-workspace/bagua/bagua/bagua_define.py", line 34, in <module>
    class BaguaHyperparameter(BaseModel):
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/main.py", line 176, in __new__
    _model_construction.complete_model_class(
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_model_construction.py", line 181, in complete_model_class
    schema = cls.__get_pydantic_core_schema__(
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/main.py", line 272, in __get_pydantic_core_schema__
    return __handler(__source)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 209, in generate_schema
    schema = self._generate_schema(obj)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 363, in _generate_schema
    return self.model_schema(obj)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 267, in model_schema
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 267, in <dictcomp>
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 556, in _generate_md_field_schema
    common_field = self._common_field_schema(name, field_info, decorators)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 597, in _common_field_schema
    schema = self._apply_annotations(
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 1222, in _apply_annotations
    return get_inner_schema(source_type)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_schema_generation_shared.py", line 177, in __call__
    return self._handler(__source_type)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 592, in generate_schema
    schema = self.generate_schema(source, from_prepare_args=False)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 209, in generate_schema
    schema = self._generate_schema(obj)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 468, in _generate_schema
    return self._generic_collection_schema(list, obj, origin)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 802, in _generic_collection_schema
    'items_schema': self.generate_schema(get_first_arg(type_)),
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 209, in generate_schema
    schema = self._generate_schema(obj)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 468, in _generate_schema
    return self._generic_collection_schema(list, obj, origin)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 802, in _generic_collection_schema
    'items_schema': self.generate_schema(get_first_arg(type_)),
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 209, in generate_schema
    schema = self._generate_schema(obj)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 403, in _generate_schema
    return self._typed_dict_schema(obj, None)
  File "/home/wr/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic-2.0a4-py3.10.egg/pydantic/_internal/_generate_schema.py", line 702, in _typed_dict_schema
    raise PydanticUserError(
pydantic.errors.PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.

For further information visit https://errors.pydantic.dev/2.0a4/u/typed-dict-version
```
